### PR TITLE
Disable jupyter token authentication

### DIFF
--- a/ipython-notebook/install-ipython-notebook
+++ b/ipython-notebook/install-ipython-notebook
@@ -9,7 +9,7 @@ cd /home/hadoop
 sudo pip install virtualenv
 mkdir IPythonNB
 cd IPythonNB
-/usr/local/bin/virtualenv -p /usr/bin/python2.7 venv
+virtualenv -p /usr/bin/python2.7 venv
 source venv/bin/activate
 
 #Install ipython and dependency
@@ -26,5 +26,6 @@ echo "c = get_config()" >  /home/hadoop/.ipython/profile_default/ipython_noteboo
 echo "c.NotebookApp.ip = '*'" >>  /home/hadoop/.ipython/profile_default/ipython_notebook_config.py
 echo "c.NotebookApp.open_browser = False"  >>  /home/hadoop/.ipython/profile_default/ipython_notebook_config.py
 echo "c.NotebookApp.port = 8192" >>  /home/hadoop/.ipython/profile_default/ipython_notebook_config.py
+echo "c.NotebookApp.token = ''" >>  /home/hadoop/.ipython/profile_default/ipython_notebook_config.py # disable token based auth
 nohup ipython notebook --no-browser > /mnt/var/log/python_notebook.log &
 fi


### PR DESCRIPTION
[Jupyter 4.3](https://github.com/jupyter/notebook/releases/tag/4.3.0) enables token authentication by default and it is not compatible with the EMR workflow - one should log into the cluster and extract token manually from logs.