### PR TITLE
Fix shebang, failing to run on EMR 5.7.0

### DIFF
--- a/R/Hadoop/emR_bootstrap.sh
+++ b/R/Hadoop/emR_bootstrap.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # AWS EMR bootstrap script 
 # for installing open-source R (www.r-project.org) with RHadoop packages and RStudio on AWS EMR


### PR DESCRIPTION
Fixing shebang string to run the shell script properly.