### PR TITLE
Fixed hadoop bin path for download exec command

### DIFF
--- a/utilities/run-if
+++ b/utilities/run-if
@@ -74,7 +74,7 @@ def download_and_execute_command(command, args)
   # If the command starts with s3://, s3n:// or s3a://
   if command.match(/^s3[n|a]{0,1}:\/\/.*/) then
     puts "Attempting to download file '#{command}'"
-    system("/home/hadoop/bin/hadoop fs -copyToLocal #{command} ./")
+    system("/usr/bin/hadoop fs -copyToLocal #{command} ./")
     
     if $? != 0 then
       puts "Error downloading file from Amazon S3"


### PR DESCRIPTION
The hadoop bin file path /home/hadoop/bin/hadoop doesn't exist. The correct is /usr/bin/hadoop.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
